### PR TITLE
Created a new `MessageWithInputHandler` type as required to handle the new `xkcd` command feature.

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/angch/discordbot/pkg/kulll"
 	_ "github.com/angch/discordbot/pkg/meme"
 	_ "github.com/angch/discordbot/pkg/stoic"
+	_ "github.com/angch/discordbot/pkg/xkcd"
 	//	_ "github.com/angch/discordbot/pkg/ocr"
 )
 

--- a/pkg/bothandler/discord.go
+++ b/pkg/bothandler/discord.go
@@ -3,6 +3,7 @@ package bothandler
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/angch/discordbot/pkg/engineersmy"
 	"github.com/bwmarrin/discordgo"
@@ -76,6 +77,31 @@ func discordMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			})
 			if err != nil {
 				log.Println(err)
+			}
+		}
+	}
+
+	sliced_content := strings.SplitN(m.Content, " ", 2)
+	if len(sliced_content) > 1 {
+		command := sliced_content[0]
+		actual_content := sliced_content[1]
+
+		username := ""
+		if m.Author != nil {
+			username = m.Author.Username
+		}
+
+		ih, ok := MsgInputHandlers[command]
+		if ok {
+			response := ih(Request{actual_content, "discord", m.ChannelID, username})
+			if response != "" {
+				_, err := s.ChannelMessageSendComplex(m.ChannelID, &discordgo.MessageSend{
+					Content:   response,
+					Reference: m.Reference(),
+				})
+				if err != nil {
+					log.Println(err)
+				}
 			}
 		}
 	}

--- a/pkg/bothandler/irc.go
+++ b/pkg/bothandler/irc.go
@@ -94,6 +94,30 @@ func (s *IrcMessagePlatform) ProcessMessages() {
 						}
 					}
 				}
+
+				sliced_content := strings.SplitN(content, " ", 2)
+				if len(sliced_content) > 1 {
+					command := sliced_content[0]
+					actual_content := sliced_content[1]
+
+					ih, ok := MsgInputHandlers[command]
+					if ok {
+						response := ih(Request{actual_content, "IRC", "", ""})
+						if response != "" {
+							err := c.WriteMessage(&irc.Message{
+								Command: "PRIVMSG",
+								Params: []string{
+									channel,
+									response,
+								},
+							})
+							if err != nil {
+								log.Println(err)
+							}
+						}
+					}
+				}
+
 			}
 		}
 	})

--- a/pkg/bothandler/readline.go
+++ b/pkg/bothandler/readline.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/chzyer/readline"
 )
@@ -57,6 +58,20 @@ outer:
 		if ok {
 			response := h()
 			log.Println("Bot says", response)
+		}
+
+		sliced_content := strings.SplitN(content, " ", 2)
+		if len(sliced_content) > 1 {
+			command := sliced_content[0]
+			actual_content := sliced_content[1]
+
+			ih, ok := MsgInputHandlers[command]
+			if ok {
+				response := ih(Request{actual_content, "readline", "", ""})
+				if response != "" {
+					log.Println("Bot says", response)
+				}
+			}
 		}
 
 		// Can be better to decouple 1 to 1 of message : response

--- a/pkg/bothandler/slackbot.go
+++ b/pkg/bothandler/slackbot.go
@@ -138,6 +138,24 @@ func (s *SlackMessagePlatform) ProcessMessages() {
 								}
 							}
 						}
+
+						sliced_content := strings.SplitN(content, " ", 2)
+						if len(sliced_content) > 1 {
+							command := sliced_content[0]
+							actual_content := sliced_content[1]
+
+							ih, ok := MsgInputHandlers[command]
+							if ok {
+								response := ih(Request{actual_content, "slack", "", ""})
+								if response != "" {
+									_, _, err := s.Client.PostMessage(ev.Channel, slack.MsgOptionText(response, false))
+									if err != nil {
+										log.Println(err)
+									}
+								}
+							}
+						}
+
 					default:
 						log.Printf("Inner event %+v %T\n", ev, ev)
 					}

--- a/pkg/bothandler/struct.go
+++ b/pkg/bothandler/struct.go
@@ -11,6 +11,7 @@ type Request struct {
 }
 
 type MessageHandler func() string
+type MessageWithInputHandler func(Request) string
 type CatchallHandler func(Request) string
 type ImageHandler func(string) string
 
@@ -24,10 +25,15 @@ type MessagePlatform interface {
 type AddMessagePlatform func(MessagePlatform)
 
 var Handlers = map[string]MessageHandler{}
+var MsgInputHandlers = map[string]MessageWithInputHandler{}
 var CatchallHandlers = []CatchallHandler{}
 var ImageHandlers = []ImageHandler{}
 var AddMessagePlatforms = []AddMessagePlatform{}
 var ActiveMessagePlatforms = []MessagePlatform{}
+
+func RegisterMessageWithInputHandler(m string, h MessageWithInputHandler) {
+	MsgInputHandlers[m] = h
+}
 
 func RegisterMessageHandler(m string, h MessageHandler) {
 	Handlers[m] = h

--- a/pkg/bothandler/telegram.go
+++ b/pkg/bothandler/telegram.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/angch/discordbot/pkg/engineersmy"
@@ -79,6 +80,25 @@ func (s *TelegramMessagePlatform) ProcessMessages() {
 				_, err := s.Client.Send(msg)
 				if err != nil {
 					log.Println(err)
+				}
+			}
+		}
+
+		sliced_content := strings.SplitN(content, " ", 2)
+		if len(sliced_content) > 1 {
+			command := sliced_content[0]
+			actual_content := sliced_content[1]
+
+			ih, ok := MsgInputHandlers[command]
+			if ok {
+				response := ih(Request{actual_content, "telegram", "", ""})
+				if response != "" {
+					msg := tgbotapi.NewMessage(update.Message.Chat.ID, response)
+					msg.ReplyToMessageID = update.Message.MessageID
+					_, err := s.Client.Send(msg)
+					if err != nil {
+						log.Println(err)
+					}
 				}
 			}
 		}

--- a/pkg/xkcd/xkcd.go
+++ b/pkg/xkcd/xkcd.go
@@ -1,0 +1,53 @@
+package xkcd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/angch/discordbot/pkg/bothandler"
+)
+
+func init() {
+	bothandler.RegisterMessageWithInputHandler("!xkcd", GetXKCD)
+	bothandler.RegisterMessageWithInputHandler("!explainxkcd", GetXKCDExplained)
+}
+
+func GetXKCD(request bothandler.Request) string {
+	input := request.Content
+
+	base_url := "https://www.xkcd.com/"
+
+	resp_url := fmt.Sprintf("%s%s/", base_url, input)
+
+	resp, err := http.Get(resp_url)
+
+	if err != nil {
+		fmt.Println("Error retrieving explainxkcd link: ", err)
+		return ""
+	}
+
+	defer resp.Body.Close()
+
+	message := resp_url
+	return message
+}
+
+func GetXKCDExplained(request bothandler.Request) string {
+	input := request.Content
+
+	base_url := "https://www.explainxkcd.com/wiki/index.php/"
+
+	resp_url := fmt.Sprintf("%s%s", base_url, input)
+
+	resp, err := http.Get(resp_url)
+
+	if err != nil {
+		fmt.Println("Error retrieving explainxkcd link: ", err)
+		return ""
+	}
+
+	defer resp.Body.Close()
+
+	message := resp_url
+	return message
+}


### PR DESCRIPTION
- This type handles messages with a command and an argument (e.g. `!xkcd 241`).
- A function for registering the new handler type was also included.
- Added support of `MessageWithInputHandler` in all messaging platforms.

Side note: Not entirely sure this implementation is good. Only tested it via the `discordbot testbot` (readline platform) so **hic sunt dracones (Here be dragons!)🐉** (I guess 🤣)