### PR TITLE
chore: Update setup-go to v3.5.0 and fix test failures

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,12 +44,13 @@ jobs:
       run: cp target/release/libuwu.so ../
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3.5.0
       with:
-        go-version: 1.15
+        go-version: 'stable'
 
     - name: Build
       run: go build -ldflags="-r lib" -v ./...
 
     - name: Test
-      run: go test -ldflags="-r lib" -v ./...
+      # Hacks to make this uwu lib work. :<
+      run: LD_LIBRARY_PATH=`pwd`/lib go test -ldflags="-r lib" -v ./...

--- a/pkg/echo/echo_test.go
+++ b/pkg/echo/echo_test.go
@@ -12,7 +12,7 @@ func TestEchoHandler(t *testing.T) {
 		args string
 		want string
 	}{
-		{"1", "uwu", ""},
+		{"1", "uwu", "(ꈍᴗꈍ)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Builds fail seem to suggest it is caused by go version `v1.15` used in github actions. This intends to fix that.